### PR TITLE
Never render before render is explicitly called

### DIFF
--- a/src/CSSUtil.jl
+++ b/src/CSSUtil.jl
@@ -35,7 +35,7 @@ struct Fallthrough
 end
 
 wrapnode(n::Node) = n
-wrapnode(x) = Node{Fallthrough}(x)
+wrapnode(x) = node(Fallthrough(), x)
 
 function WebIO.render(n::Node{Fallthrough})
     WebIO.render(first(children(n)))(props(n))

--- a/src/CSSUtil.jl
+++ b/src/CSSUtil.jl
@@ -34,16 +34,19 @@ till its parents have been rendered
 struct Fallthrough
 end
 
+wrapnode(n::Node) = n
+wrapnode(x) = Node{Fallthrough}(x)
+
 function WebIO.render(n::Node{Fallthrough})
     WebIO.render(first(children(n)))(props(n))
 end
 
 function style(elem, dict::Dict)
-    Node{Fallthrough}(elem)(style(dict))
+    wrapnode(elem)(style(dict))
 end
 
 function style(elem, p::Pair...)
-    Node{Fallthrough}(elem)(style(p...))
+    wrapnode(elem)(style(p...))
 end
 
 function style(::Nothing, arg::Pair...)

--- a/src/CSSUtil.jl
+++ b/src/CSSUtil.jl
@@ -23,12 +23,27 @@ function style(p::Pair...)
     style(Dict(p...))
 end
 
+"""
+When a Node's `instanceof` field is set to `Fallthrough()`
+it renders it only child and places it in place of itself
+("splat"s its children with the Node's own siblings)
+
+This is useful when you want to defer rendering an object
+till its parents have been rendered
+"""
+struct Fallthrough
+end
+
+function WebIO.render(n::Node{Fallthrough})
+    WebIO.render(first(children(n)))(props(n))
+end
+
 function style(elem, dict::Dict)
-    render(elem)(style(dict))
+    Node{Fallthrough}(elem)(style(dict))
 end
 
 function style(elem, p::Pair...)
-    render(elem)(style(p...))
+    Node{Fallthrough}(elem)(style(p...))
 end
 
 function style(::Nothing, arg::Pair...)

--- a/src/CSSUtil.jl
+++ b/src/CSSUtil.jl
@@ -54,7 +54,7 @@ function style(::Nothing, arg::Dict)
     style(arg)
 end
 
-const empty = dom"div"()
+empty() = dom"div"()
 
 export mm, em, cm, inch, pt, px, vw, vh, vmin, cent
 "1mm"

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -49,8 +49,8 @@ function vbox(elems::AbstractVector)
 end
 vbox(xs...) = vbox([xs...])
 
-hskip(x) = boxsize(x, 0px, empty)
-vskip(y) = boxsize(0px, y, empty)
+hskip(x) = boxsize(x, 0px, empty())
+vskip(y) = boxsize(0px, y, empty())
 
 function wrap(elem=nothing; reverse=false)
     style(elem, "flex-wrap" => reverse ? "wrap-reverse" : "wrap")

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -35,7 +35,7 @@ container(xs...) = container([xs...])
     Horizontally align mulitple web components.
 """
 function hbox(elems::AbstractVector)
-    container(map(render, elems))(style("display" => "flex", "flex-direction"=>"row"))
+    container(elems)(style("display" => "flex", "flex-direction"=>"row"))
 end
 hbox(xs...) = hbox([xs...])
 
@@ -45,7 +45,7 @@ hbox(xs...) = hbox([xs...])
     Vertically align mulitple web components.
 """
 function vbox(elems::AbstractVector)
-    container(map(render, elems))(style("display" => "flex", "flex-direction"=>"column"))
+    container(elems)(style("display" => "flex", "flex-direction"=>"column"))
 end
 vbox(xs...) = vbox([xs...])
 


### PR DESCRIPTION
Introduces a `Fallthrough` instance type for `Node` which accumulates props but forwards it to its only child when rendered.

Also fixed a problem with a const and precompilation.